### PR TITLE
docs: clarify API key support requires v0.6.0+

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -9,7 +9,7 @@ Mendaftarkan 9Router sebagai custom provider di OpenCode dengan auto-discovery m
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@vheins/opencode-9router@0.5.0"]
+  "plugin": ["@vheins/opencode-9router@0.6.0"]
 }
 ```
 
@@ -33,7 +33,7 @@ Plugin akan otomatis mendeteksi model dari `http://localhost:20128` (default).
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@vheins/opencode-9router@0.5.0"]
+  "plugin": ["@vheins/opencode-9router@0.6.0"]
 }
 ```
 
@@ -46,7 +46,7 @@ Jika 9Router berjalan di host atau port yang berbeda, tambahkan konfigurasi prov
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@vheins/opencode-9router@0.5.0"],
+  "plugin": ["@vheins/opencode-9router@0.6.0"],
   "provider": {
     "9router": {
       "options": {
@@ -59,10 +59,12 @@ Jika 9Router berjalan di host atau port yang berbeda, tambahkan konfigurasi prov
 
 ### Dengan API Key
 
+> **Membutuhkan v0.6.0+** — Versi sebelumnya tidak mengirimkan API key saat penemuan model, yang menyebabkan error 401 jika instansi 9Router Anda memerlukan autentikasi.
+
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@vheins/opencode-9router@0.5.0"],
+  "plugin": ["@vheins/opencode-9router@0.6.0"],
   "provider": {
     "9router": {
       "options": {
@@ -125,13 +127,13 @@ opencode
 ## Cara Kerja
 
 ```
-opencode.json "plugin": ["@vheins/opencode-9router@0.5.0"]
+opencode.json "plugin": ["@vheins/opencode-9router@0.6.0"]
   ↓
 Bun menginstal paket dari npm
   ↓
 Plugin dimuat saat startup:
-  1. Baca baseURL dari konfigurasi provider (atau gunakan default http://localhost:20128)
-  2. Coba GET /v1/models dari baseURL (timeout 3 detik)
+  1. Baca baseURL dan apiKey dari konfigurasi provider (atau gunakan default)
+  2. Coba GET /v1/models dari baseURL (timeout 3 detik, dengan header auth jika apiKey tersedia)
   3. Jika berhasil → daftarkan model langsung
   4. Jika gagal → log peringatan, tidak ada model yang didaftarkan
   ↓

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Registers 9Router as a custom provider in OpenCode with auto-discovery of models
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@vheins/opencode-9router@0.5.0"]
+  "plugin": ["@vheins/opencode-9router@0.6.0"]
 }
 ```
 
@@ -33,7 +33,7 @@ The plugin will auto-discover models from `http://localhost:20128` (default).
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@vheins/opencode-9router@0.5.0"]
+  "plugin": ["@vheins/opencode-9router@0.6.0"]
 }
 ```
 
@@ -46,7 +46,7 @@ If 9Router is running on a different host or port, add a provider config:
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@vheins/opencode-9router@0.5.0"],
+  "plugin": ["@vheins/opencode-9router@0.6.0"],
   "provider": {
     "9router": {
       "options": {
@@ -59,10 +59,12 @@ If 9Router is running on a different host or port, add a provider config:
 
 ### With API Key
 
+> **Requires v0.6.0+** — Earlier versions do not pass the API key during model discovery, which causes 401 errors if your 9Router instance requires authentication.
+
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@vheins/opencode-9router@0.5.0"],
+  "plugin": ["@vheins/opencode-9router@0.6.0"],
   "provider": {
     "9router": {
       "options": {
@@ -125,13 +127,13 @@ opencode
 ## How It Works
 
 ```
-opencode.json "plugin": ["@vheins/opencode-9router@0.5.0"]
+opencode.json "plugin": ["@vheins/opencode-9router@0.6.0"]
   ↓
 Bun installs the package from npm
   ↓
 Plugin loads at startup:
-  1. Read baseURL from provider config (or use default http://localhost:20128)
-  2. Try GET /v1/models from baseURL (3s timeout)
+  1. Read baseURL and apiKey from provider config (or use defaults)
+  2. Try GET /v1/models from baseURL (3s timeout, with auth header if apiKey provided)
   3. If OK → register live models
   4. If fail → log warning, no models registered
   ↓


### PR DESCRIPTION
## Problem

The README shows API key configuration examples with `@0.5.0`, but v0.5.0 does **not** pass the API key to the model discovery endpoint (`GET /v1/models`). This causes **401 Unauthorized** errors when the 9Router instance requires authentication.

## Root Cause

In v0.5.0, `discoverModels()` only takes `baseURL` -- the API key from the provider config is ignored during discovery. The `apiKey` parameter was added in v0.6.0.

```
# v0.5.0 -- no auth header sent -> 401
curl http://homelab:20128/v1/models
# => 401 Unauthorized

# v0.6.0 -- auth header sent -> 200
curl -H "Authorization: Bearer <key>" http://homelab:20128/v1/models
# => 200 OK, 41 models
```

## Changes

- Update all version references from `0.5.0` to `0.6.0`
- Add callout that API key support requires v0.6.0+
- Update "How It Works" to mention apiKey in the discovery step
- Users with auth-required 9Router instances must use v0.6.0+

## Related

Users hitting this issue will see this in OpenCode logs:

```
Failed to discover models from http://<host>:20128/v1. Check if 9Router is running and accessible.
```
